### PR TITLE
Support for local skin file, and don't run default code when included

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ php Minecraft 3D Skin Renderer
 
 ***This fork by Rodney. I've submitted a pull request back to Gyzie - if this is accepted then this fork will become redundant.***
 
-*Readme from Gyzie follows (with an edit by Rodney)
+*Readme from Gyzie follows (with an edit by Rodney)*
 
 Render a 3D view of a Minecraft skin using PHP.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 php Minecraft 3D Skin Renderer
 =====================
 
+***This fork by Rodney. I've submitted a pull request back to Gyzie - if this is accepted then this fork will become redundant.***
+
+*Readme from Gyzie follows (with an edit by Rodney)
+
 Render a 3D view of a Minecraft skin using PHP.
 
 Project first developed by <a href="https://github.com/supermamie/php-Minecraft-3D-skin" target="_blank">supermamie</a>. Later transalated to English by <a href="https://github.com/cajogos/php-Minecraft-3D-Skin-Renderer" target="_blank">cajogos</a>.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Parameters are now optional (exept for `user`), so you can now only add those yo
 ### Using it as class
 You can use the script for direct browser output (via the URL method as mentioned above), but also as a class for your scripts. Example:
 
-```
+```php
 include_once realpath(dirname(__FILE__) . '/3d.php');
 	
 $player = new render3DPlayer('Notch', '-25', '-25', '10', '5', '-2', '-20', '2', 'true', 'false', 'png', '12', 'true', 'true'); //render3DPlayer(user, vr, hr, hrh, vrll, vrrl, vrla, vrra, displayHair, headOnly, format, ratio, aa, layers)
@@ -56,6 +56,13 @@ $player = new render3DPlayer('Notch', '-25', '-25', '10', '5', '-2', '-20', '2',
 $svg = $player->get3DRender();
 echo "<br/>====<br/>SVG:<br/>====<br/>";
 echo $svg; // SVG String
+
+// As above (svg example) but with a locally provided file
+$player = new render3DPlayer('', '-25', '-25', '10', '5', '-2', '-20', '2', 'true', 'false', 'svg', '12', 'true', 'true', 'someskinfile.png');
+$svg = $player->get3DRender();
+echo "<br/>====<br/>SVG:<br/>====<br/>";
+echo $svg; // SVG String
+
 ```
 
 ### Changes Made


### PR DESCRIPTION
Some improvements for library use:
    1) If the file has been included, it is not our place to adjust the error reporting.
    2) If the file has been included, do not generate an output by default. Previously, the script output to the browser/stdout just because $_GET['user'] contains some text - as a library function we should not make assumptions about the URL parameters that are really the business of the page that called us.
    3) Allow the caller to provide a local file instead of downloading from Mojang.
